### PR TITLE
asprintf in tests

### DIFF
--- a/tests/mock_client.c
+++ b/tests/mock_client.c
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "linked_list_hashmap.h"
 #include "bipbuffer.h"
+#include "asprintf.h"
 
 #include <fcntl.h>
 #include <sys/time.h>

--- a/tests/mock_torrent.c
+++ b/tests/mock_torrent.c
@@ -12,6 +12,7 @@
 #include "mt19937ar.h"
 #include "bt.h"
 #include "sha1.h"
+#include "asprintf.h"
 
 typedef struct
 {

--- a/tests/test_scenario_share_20_pieces.c
+++ b/tests/test_scenario_share_20_pieces.c
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "linked_list_hashmap.h"
 #include "bipbuffer.h"
+#include "asprintf.h"
 
 #include <fcntl.h>
 #include <sys/time.h>

--- a/tests/test_scenario_shares_all_pieces.c
+++ b/tests/test_scenario_shares_all_pieces.c
@@ -28,6 +28,7 @@
 #include "config.h"
 #include "linked_list_hashmap.h"
 #include "bipbuffer.h"
+#include "asprintf.h"
 
 #include <fcntl.h>
 #include <sys/time.h>

--- a/tests/test_scenario_shares_all_pieces_between_each_other.c
+++ b/tests/test_scenario_shares_all_pieces_between_each_other.c
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "linked_list_hashmap.h"
 #include "bipbuffer.h"
+#include "asprintf.h"
 
 #include <fcntl.h>
 #include <sys/time.h>

--- a/tests/test_scenario_three_peers_share_all_pieces_between_each_other.c
+++ b/tests/test_scenario_three_peers_share_all_pieces_between_each_other.c
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "linked_list_hashmap.h"
 #include "bipbuffer.h"
+#include "asprintf.h"
 
 #include <fcntl.h>
 #include <sys/time.h>

--- a/wscript
+++ b/wscript
@@ -68,6 +68,7 @@ def scenario_test(bld, src, ccflag=None):
             "tests/mock_torrent.c",
             "tests/mock_client.c",
             ] + bld.clib_c_files("""
+                asprintf
                 bipbuffer
                 cutest
                 sha1
@@ -89,6 +90,7 @@ def scenario_test(bld, src, ccflag=None):
             "./include",
             "./tests"
             ] + bld.clib_h_paths("""
+                asprintf
                 bipbuffer
                 config-re
                 bitfield


### PR DESCRIPTION
- `#include "asprintf.h"` in failed tests
- Added `asprintf` to `bld.clib_c_files` and `bld.clib_h_paths` in `scenario_test`.
